### PR TITLE
feat: add away-only areas option to suppress ARM_HOME per area

### DIFF
--- a/custom_components/inim_alarm/__init__.py
+++ b/custom_components/inim_alarm/__init__.py
@@ -22,6 +22,7 @@ from .const import (
     ATTR_ZONE_ID,
     CONF_ARM_AWAY_SCENARIO,
     CONF_ARM_HOME_SCENARIO,
+    CONF_AWAY_ONLY_AREAS,
     CONF_DISARM_SCENARIO,
     CONF_ENABLE_SIA,
     CONF_SCAN_INTERVAL,
@@ -92,6 +93,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             CONF_ARM_AWAY_SCENARIO: entry.options.get(CONF_ARM_AWAY_SCENARIO),
             CONF_ARM_HOME_SCENARIO: entry.options.get(CONF_ARM_HOME_SCENARIO),
             CONF_DISARM_SCENARIO: entry.options.get(CONF_DISARM_SCENARIO),
+            CONF_AWAY_ONLY_AREAS: entry.options.get(CONF_AWAY_ONLY_AREAS, []),
         },
     }
 

--- a/custom_components/inim_alarm/alarm_control_panel.py
+++ b/custom_components/inim_alarm/alarm_control_panel.py
@@ -30,6 +30,7 @@ from .const import (
     ATTR_VOLTAGE,
     CONF_ARM_AWAY_SCENARIO,
     CONF_ARM_HOME_SCENARIO,
+    CONF_AWAY_ONLY_AREAS,
     CONF_DISARM_SCENARIO,
     CONF_SCAN_INTERVAL,
     CONF_USER_CODE,
@@ -381,6 +382,13 @@ class InimAreaAlarmControlPanel(
         # Track arming state and mode
         self._pending_state: AlarmControlPanelState | None = None
         self._armed_mode: str = "home"  # "home" or "away" - default to home
+
+        away_only_areas = {
+            str(value)
+            for value in self._options.get(CONF_AWAY_ONLY_AREAS, [])
+        }
+        if str(area_id) in away_only_areas:
+            self._attr_supported_features = AlarmControlPanelEntityFeature.ARM_AWAY
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/inim_alarm/config_flow.py
+++ b/custom_components/inim_alarm/config_flow.py
@@ -19,6 +19,7 @@ from homeassistant.helpers import config_validation as cv, selector
 from .const import (
     CONF_ARM_AWAY_SCENARIO,
     CONF_ARM_HOME_SCENARIO,
+    CONF_AWAY_ONLY_AREAS,
     CONF_DISARM_SCENARIO,
     CONF_ENABLE_SIA,
     CONF_SCAN_INTERVAL,
@@ -172,11 +173,7 @@ class InvalidAuth(Exception):
 
 
 class InimAlarmOptionsFlow(config_entries.OptionsFlow):
-    """Handle options flow for INIM Alarm.
-    
-    Options only include polling interval - scenarios are no longer needed
-    since the main panel uses InsertAreas API directly.
-    """
+    """Handle options flow for INIM Alarm."""
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -203,6 +200,7 @@ class InimAlarmOptionsFlow(config_entries.OptionsFlow):
 
         # Build the scenario list from the coordinator so users pick by name.
         scenario_options = self._build_scenario_options()
+        area_options = self._build_area_options()
 
         scenario_schema: dict[Any, Any] = {}
         if scenario_options:
@@ -225,6 +223,24 @@ class InimAlarmOptionsFlow(config_entries.OptionsFlow):
                 )
                 scenario_schema[field] = scenario_selector
 
+        area_schema: dict[Any, Any] = {}
+        if area_options:
+            current_away_only = self.config_entry.options.get(
+                CONF_AWAY_ONLY_AREAS, []
+            )
+            area_schema[
+                vol.Optional(
+                    CONF_AWAY_ONLY_AREAS,
+                    default=current_away_only,
+                )
+            ] = selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=area_options,
+                    multiple=True,
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                )
+            )
+
         options_schema = vol.Schema(
             {
                 vol.Required(
@@ -244,6 +260,7 @@ class InimAlarmOptionsFlow(config_entries.OptionsFlow):
                     default=current_sia_account,
                 ): str,
                 **scenario_schema,
+                **area_schema,
             }
         )
 
@@ -271,6 +288,31 @@ class InimAlarmOptionsFlow(config_entries.OptionsFlow):
                         selector.SelectOptionDict(
                             value=value,
                             label=scenario.get("Name", f"Scenario {scenario_id}"),
+                        )
+                    )
+        except (KeyError, AttributeError, TypeError):
+            pass
+        return options
+
+    def _build_area_options(self) -> list[selector.SelectOptionDict]:
+        """Return alarm areas as selector options (value=id, label=name)."""
+        options: list[selector.SelectOptionDict] = []
+        seen: set[str] = set()
+        try:
+            coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id]["coordinator"]
+            for device in coordinator.data.get("devices", []):
+                for area in device.get("areas", []):
+                    area_id = area.get("AreaId")
+                    if area_id is None:
+                        continue
+                    value = str(area_id)
+                    if value in seen:
+                        continue
+                    seen.add(value)
+                    options.append(
+                        selector.SelectOptionDict(
+                            value=value,
+                            label=area.get("Name", f"Area {area_id}"),
                         )
                     )
         except (KeyError, AttributeError, TypeError):

--- a/custom_components/inim_alarm/const.py
+++ b/custom_components/inim_alarm/const.py
@@ -16,6 +16,7 @@ CONF_ARM_AWAY_SCENARIO = "arm_away_scenario"
 CONF_ARM_HOME_SCENARIO = "arm_home_scenario"
 CONF_DISARM_SCENARIO = "disarm_scenario"
 CONF_USER_CODE = "user_code"
+CONF_AWAY_ONLY_AREAS = "away_only_areas"
 
 # SIA-IP configuration
 CONF_ENABLE_SIA = "enable_sia"

--- a/custom_components/inim_alarm/strings.json
+++ b/custom_components/inim_alarm/strings.json
@@ -37,7 +37,7 @@
     "step": {
       "init": {
         "title": "INIM Alarm Options",
-        "description": "Configure polling interval, SIA-IP local listener and scenario mapping.",
+        "description": "Configure polling, SIA-IP, scenario mapping and area arming modes.",
         "data": {
           "scan_interval": "Polling interval (seconds)",
           "enable_sia": "Enable SIA-IP listener",
@@ -45,7 +45,8 @@
           "sia_account": "SIA Account ID (optional)",
           "arm_away_scenario": "Armed Away scenario",
           "arm_home_scenario": "Armed Home scenario",
-          "disarm_scenario": "Disarm scenario"
+          "disarm_scenario": "Disarm scenario",
+          "away_only_areas": "Away-only areas"
         },
         "data_description": {
           "scan_interval": "How often to poll for updates (10-300 seconds)",
@@ -54,7 +55,8 @@
           "sia_account": "Filter messages by SIA account ID. Leave empty to accept all.",
           "arm_away_scenario": "Panel scenario to activate for Armed Away (e.g. Total). Leave empty to arm all areas.",
           "arm_home_scenario": "Panel scenario to activate for Armed Home (e.g. Night/partial). Leave empty to arm all areas.",
-          "disarm_scenario": "Panel scenario to activate for Disarm. Leave empty to disarm all areas."
+          "disarm_scenario": "Panel scenario to activate for Disarm. Leave empty to disarm all areas.",
+          "away_only_areas": "Areas that should offer Armed Away but not Armed Home."
         }
       }
     }

--- a/custom_components/inim_alarm/translations/en.json
+++ b/custom_components/inim_alarm/translations/en.json
@@ -37,7 +37,7 @@
     "step": {
       "init": {
         "title": "INIM Alarm Options",
-        "description": "Configure polling interval, SIA-IP local listener and scenario mapping.",
+        "description": "Configure polling, SIA-IP, scenario mapping and area arming modes.",
         "data": {
           "scan_interval": "Polling interval (seconds)",
           "enable_sia": "Enable SIA-IP listener",
@@ -45,7 +45,8 @@
           "sia_account": "SIA Account ID (optional)",
           "arm_away_scenario": "Armed Away scenario",
           "arm_home_scenario": "Armed Home scenario",
-          "disarm_scenario": "Disarm scenario"
+          "disarm_scenario": "Disarm scenario",
+          "away_only_areas": "Away-only areas"
         },
         "data_description": {
           "scan_interval": "How often to poll for updates (10-300 seconds)",
@@ -54,7 +55,8 @@
           "sia_account": "Filter messages by SIA account ID. Leave empty to accept all.",
           "arm_away_scenario": "Panel scenario to activate for Armed Away (e.g. Total). Leave empty to arm all areas.",
           "arm_home_scenario": "Panel scenario to activate for Armed Home (e.g. Night/partial). Leave empty to arm all areas.",
-          "disarm_scenario": "Panel scenario to activate for Disarm. Leave empty to disarm all areas."
+          "disarm_scenario": "Panel scenario to activate for Disarm. Leave empty to disarm all areas.",
+          "away_only_areas": "Areas that should offer Armed Away but not Armed Home."
         }
       }
     }

--- a/custom_components/inim_alarm/translations/it.json
+++ b/custom_components/inim_alarm/translations/it.json
@@ -37,7 +37,7 @@
     "step": {
       "init": {
         "title": "Opzioni INIM Alarm",
-        "description": "Configura l'intervallo di polling, il listener SIA-IP locale e la mappatura degli scenari.",
+        "description": "Configura polling, SIA-IP, mappatura degli scenari e modalita di inserimento delle aree.",
         "data": {
           "scan_interval": "Intervallo di polling (secondi)",
           "enable_sia": "Abilita listener SIA-IP",
@@ -45,7 +45,8 @@
           "sia_account": "Account SIA (opzionale)",
           "arm_away_scenario": "Scenario Inserimento Totale",
           "arm_home_scenario": "Scenario Inserimento Parziale",
-          "disarm_scenario": "Scenario Disinserimento"
+          "disarm_scenario": "Scenario Disinserimento",
+          "away_only_areas": "Aree solo inserimento totale"
         },
         "data_description": {
           "scan_interval": "Frequenza aggiornamento dati (10-300 secondi)",
@@ -54,7 +55,8 @@
           "sia_account": "Filtra messaggi per ID account SIA. Lascia vuoto per accettare tutti.",
           "arm_away_scenario": "Scenario del pannello da attivare per l'inserimento totale (es. Totale). Lascia vuoto per inserire tutte le aree.",
           "arm_home_scenario": "Scenario del pannello da attivare per l'inserimento parziale (es. Notte/parziale). Lascia vuoto per inserire tutte le aree.",
-          "disarm_scenario": "Scenario del pannello da attivare per il disinserimento. Lascia vuoto per disinserire tutte le aree."
+          "disarm_scenario": "Scenario del pannello da attivare per il disinserimento. Lascia vuoto per disinserire tutte le aree.",
+          "away_only_areas": "Aree che devono offrire solo Inserimento Totale, senza Inserimento Parziale."
         }
       }
     }


### PR DESCRIPTION
## Summary

Some alarm partitions in my installation (e.g. a terrace or basement) should only be armed in **Away** mode — showing a Home button for them is confusing and potentially dangerous (we don't need the 3rd state for these ones). This PR adds an optional config setting that lets users designate which areas are Away-only.

The user can select on the configuration of the plugin which areas they want to only have 2 states instead of 3.

- **`const.py`**: adds `CONF_AWAY_ONLY_AREAS` constant
- **`config_flow.py`**: adds a `SelectSelector` multi-select to the options flow, dynamically populated from coordinator area data so users pick areas by name
- **`__init__.py`**: passes all extra options through to `hass.data` so platforms can read them (previously only `scan_interval` and `user_code` were forwarded)
- **`alarm_control_panel.py`**: reads `CONF_AWAY_ONLY_AREAS` in `InimAreaAlarmControlPanel.__init__` and restricts `supported_features` to `ARM_AWAY` for designated areas — this removes the Armed Home button from the alarm-panel card for those areas

## Behaviour

- Default: no change — all areas work exactly as before
- When areas are selected in the options UI, those areas expose only `AlarmControlPanelEntityFeature.ARM_AWAY`, so HA's alarm-panel card shows only "Armed Away" and "Disarmed"

## Test plan

- [ ] Open integration options — new "Away-only areas" multi-select appears, populated with area names
- [ ] Select one or more areas and save; reload the integration
- [ ] Verify selected area panels show only Armed Away + Disarmed buttons
- [ ] Verify unselected areas still show all three states
- [ ] With no areas selected, behaviour is identical to before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)