### PR TITLE
feat: add explicit per-area scenario mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ Go to **Settings** → **Devices & Services** → **INIM Alarm** → **Configure
 | **Enable SIA-IP** | Enable local SIA-IP TCP listener | Off |
 | **SIA-IP Port** | TCP port for SIA-IP listener | 6001 |
 | **SIA Account ID** | Filter by SIA account (leave empty for all) | Empty |
+| **Armed Away / Armed Home / Disarm scenario** | Optional scenarios for the main alarm control | Empty |
+| **Away-only areas** | Areas that should offer Armed Away but not Armed Home | Empty |
+| **Per-area scenario mappings** | Optional scenario mappings for individual area controls | Empty |
+
+#### Scenario mappings
+
+Scenario mappings are optional. If no scenario is configured, the integration keeps using the `InsertAreas` API with your configured user code.
+
+The main alarm control and the individual area controls have separate scenario mappings, even though they use the same action names:
+
+- **Main alarm scenarios** apply to `alarm_control_panel.<name>` and are useful when one panel scenario should arm or disarm all configured areas.
+- **Per-area scenario mappings** apply to `alarm_control_panel.<area_name>` and are useful when a specific area needs its own explicit Away, Home, or Disarm scenario.
 
 ### SIA-IP Setup (Optional)
 

--- a/custom_components/inim_alarm/__init__.py
+++ b/custom_components/inim_alarm/__init__.py
@@ -20,6 +20,7 @@ from .const import (
     ATTR_DEVICE_ID,
     ATTR_SCENARIO_ID,
     ATTR_ZONE_ID,
+    CONF_AREA_SCENARIOS,
     CONF_ARM_AWAY_SCENARIO,
     CONF_ARM_HOME_SCENARIO,
     CONF_AWAY_ONLY_AREAS,
@@ -94,6 +95,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             CONF_ARM_HOME_SCENARIO: entry.options.get(CONF_ARM_HOME_SCENARIO),
             CONF_DISARM_SCENARIO: entry.options.get(CONF_DISARM_SCENARIO),
             CONF_AWAY_ONLY_AREAS: entry.options.get(CONF_AWAY_ONLY_AREAS, []),
+            CONF_AREA_SCENARIOS: entry.options.get(CONF_AREA_SCENARIOS, {}),
         },
     }
 

--- a/custom_components/inim_alarm/alarm_control_panel.py
+++ b/custom_components/inim_alarm/alarm_control_panel.py
@@ -496,7 +496,7 @@ class InimAreaAlarmControlPanel(
         """Run an area action via its mapped scenario or InsertAreas fallback."""
         scenario_id = self._configured_scenario(conf_key)
         if scenario_id is not None:
-            self.coordinator.register_ha_command(self._device_id, self._area_id)
+            self.coordinator.register_ha_command(self._device_id, None)
             _LOGGER.info(
                 "%s area '%s' via scenario %s",
                 action,

--- a/custom_components/inim_alarm/alarm_control_panel.py
+++ b/custom_components/inim_alarm/alarm_control_panel.py
@@ -28,6 +28,7 @@ from .const import (
     ATTR_MODEL,
     ATTR_SERIAL_NUMBER,
     ATTR_VOLTAGE,
+    CONF_AREA_SCENARIOS,
     CONF_ARM_AWAY_SCENARIO,
     CONF_ARM_HOME_SCENARIO,
     CONF_AWAY_ONLY_AREAS,
@@ -387,8 +388,27 @@ class InimAreaAlarmControlPanel(
             str(value)
             for value in self._options.get(CONF_AWAY_ONLY_AREAS, [])
         }
-        if str(area_id) in away_only_areas:
+        self._away_only = str(area_id) in away_only_areas
+        if self._away_only:
             self._attr_supported_features = AlarmControlPanelEntityFeature.ARM_AWAY
+
+    def _configured_scenario(self, conf_key: str) -> int | None:
+        """Return the scenario explicitly mapped to this area's action."""
+        area_ref = f"{self._device_id}:{self._area_id}"
+        mapping = self._options.get(CONF_AREA_SCENARIOS, {}).get(area_ref, {})
+        value = mapping.get(conf_key)
+        if value in (None, ""):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            _LOGGER.warning(
+                "Invalid scenario configured for area %s action %s: %r",
+                area_ref,
+                conf_key,
+                value,
+            )
+            return None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -431,7 +451,12 @@ class InimAreaAlarmControlPanel(
             # Reset armed mode to default when disarmed
             self._armed_mode = "home"
             return AlarmControlPanelState.DISARMED
-        
+
+        if self._away_only:
+            # Away-only areas cannot represent an armed-home state in Home Assistant.
+            self._armed_mode = "away"
+            return AlarmControlPanelState.ARMED_AWAY
+
         # Return armed state based on the mode set when arming
         if self._armed_mode == "away":
             return AlarmControlPanelState.ARMED_AWAY
@@ -465,70 +490,88 @@ class InimAreaAlarmControlPanel(
         
         return attrs
 
-    async def async_alarm_disarm(self, code: str | None = None) -> None:
-        """Send disarm command for this area."""
+    async def _async_run_action(
+        self, action: str, conf_key: str, arm: bool
+    ) -> bool:
+        """Run an area action via its mapped scenario or InsertAreas fallback."""
+        scenario_id = self._configured_scenario(conf_key)
+        if scenario_id is not None:
+            self.coordinator.register_ha_command(self._device_id, self._area_id)
+            _LOGGER.info(
+                "%s area '%s' via scenario %s",
+                action,
+                self._area_name,
+                scenario_id,
+            )
+            await self._api.activate_scenario(self._device_id, scenario_id)
+            return True
+
         if not self._user_code:
             _LOGGER.error(
-                "Cannot disarm area %s: No user code configured. "
-                "Reconfigure the integration to set the user code.",
-                self._area_name
+                "Cannot %s area %s: configure an area scenario or set the user code.",
+                action.lower(),
+                self._area_name,
             )
-            return
-        
-        # Register that this command is from Home Assistant
+            return False
+
         self.coordinator.register_ha_command(self._device_id, self._area_id)
-            
-        _LOGGER.info("Disarming area '%s' (ID: %s)", self._area_name, self._area_id)
-        await self._api.insert_areas(self._device_id, [self._area_id], self._user_code, arm=False)
-        await self.coordinator.async_request_refresh()
+        _LOGGER.info(
+            "%s area '%s' via InsertAreas (ID: %s)",
+            action,
+            self._area_name,
+            self._area_id,
+        )
+        await self._api.insert_areas(
+            self._device_id,
+            [self._area_id],
+            self._user_code,
+            arm=arm,
+        )
+        return True
+
+    async def async_alarm_disarm(self, code: str | None = None) -> None:
+        """Send disarm command for this area."""
+        if await self._async_run_action(
+            "Disarming", CONF_DISARM_SCENARIO, arm=False
+        ):
+            await self.coordinator.async_request_refresh()
 
     async def async_alarm_arm_home(self, code: str | None = None) -> None:
         """Send arm home command for this area (partial protection)."""
-        if not self._user_code:
-            _LOGGER.error(
-                "Cannot arm area %s: No user code configured. "
-                "Reconfigure the integration to set the user code.",
-                self._area_name
+        if self._away_only:
+            _LOGGER.warning(
+                "Cannot arm area %s in Home mode: area is configured as Away-only",
+                self._area_name,
             )
             return
-        
-        # Set pending state and armed mode
+
         self._pending_state = AlarmControlPanelState.ARMING
         self._armed_mode = "home"
         self.async_write_ha_state()
-        
-        # Register that this command is from Home Assistant
-        self.coordinator.register_ha_command(self._device_id, self._area_id)
-            
-        _LOGGER.info("Arming HOME area '%s' (ID: %s)", self._area_name, self._area_id)
-        await self._api.insert_areas(self._device_id, [self._area_id], self._user_code, arm=True)
-        
-        # Clear pending state after API call
+
+        if not await self._async_run_action(
+            "Arming HOME", CONF_ARM_HOME_SCENARIO, arm=True
+        ):
+            self._pending_state = None
+            self.async_write_ha_state()
+            return
+
         self._pending_state = None
         await self.coordinator.async_request_refresh()
 
     async def async_alarm_arm_away(self, code: str | None = None) -> None:
         """Send arm away command for this area (full protection)."""
-        if not self._user_code:
-            _LOGGER.error(
-                "Cannot arm area %s: No user code configured. "
-                "Reconfigure the integration to set the user code.",
-                self._area_name
-            )
-            return
-        
-        # Set pending state and armed mode
         self._pending_state = AlarmControlPanelState.ARMING
         self._armed_mode = "away"
         self.async_write_ha_state()
-        
-        # Register that this command is from Home Assistant
-        self.coordinator.register_ha_command(self._device_id, self._area_id)
-            
-        _LOGGER.info("Arming AWAY area '%s' (ID: %s)", self._area_name, self._area_id)
-        await self._api.insert_areas(self._device_id, [self._area_id], self._user_code, arm=True)
-        
-        # Clear pending state after API call
+
+        if not await self._async_run_action(
+            "Arming AWAY", CONF_ARM_AWAY_SCENARIO, arm=True
+        ):
+            self._pending_state = None
+            self.async_write_ha_state()
+            return
+
         self._pending_state = None
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/inim_alarm/config_flow.py
+++ b/custom_components/inim_alarm/config_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from typing import Any
 
 import voluptuous as vol
@@ -17,6 +18,8 @@ from .api import InimApi, InimApiError, InimAuthError
 from homeassistant.helpers import config_validation as cv, selector
 
 from .const import (
+    CONF_AREA,
+    CONF_AREA_SCENARIOS,
     CONF_ARM_AWAY_SCENARIO,
     CONF_ARM_HOME_SCENARIO,
     CONF_AWAY_ONLY_AREAS,
@@ -25,6 +28,7 @@ from .const import (
     CONF_SCAN_INTERVAL,
     CONF_SIA_ACCOUNT,
     CONF_SIA_PORT,
+    CONF_REMOVE_AREA_SCENARIO_MAPPING,
     CONF_USER_CODE,
     DEFAULT_SIA_PORT,
     DOMAIN,
@@ -175,12 +179,38 @@ class InvalidAuth(Exception):
 class InimAlarmOptionsFlow(config_entries.OptionsFlow):
     """Handle options flow for INIM Alarm."""
 
+    _selected_area_ref: str | None = None
+    _selected_area_name: str | None = None
+    _selected_device_id: int | None = None
+
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage the options."""
+        return self.async_show_menu(
+            step_id="init",
+            menu_options=["general", "area_scenarios"],
+        )
+
+    async def async_step_general(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage general integration options."""
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            options = dict(self.config_entry.options)
+            for key in (
+                CONF_SCAN_INTERVAL,
+                CONF_ENABLE_SIA,
+                CONF_SIA_PORT,
+                CONF_SIA_ACCOUNT,
+                CONF_ARM_AWAY_SCENARIO,
+                CONF_ARM_HOME_SCENARIO,
+                CONF_DISARM_SCENARIO,
+                CONF_AWAY_ONLY_AREAS,
+            ):
+                options.pop(key, None)
+            options.update(user_input)
+            return self.async_create_entry(title="", data=options)
 
         # Get current values
         current_scan = self.config_entry.options.get(CONF_SCAN_INTERVAL, 30)
@@ -265,17 +295,128 @@ class InimAlarmOptionsFlow(config_entries.OptionsFlow):
         )
 
         return self.async_show_form(
-            step_id="init",
+            step_id="general",
             data_schema=options_schema,
         )
 
-    def _build_scenario_options(self) -> list[selector.SelectOptionDict]:
+    async def async_step_area_scenarios(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Select an area to configure."""
+        area_options = self._build_area_mapping_options()
+
+        if user_input is not None:
+            area_ref = user_input[CONF_AREA]
+            selected = next(
+                (option for option in area_options if option["value"] == area_ref),
+                None,
+            )
+            if selected is not None:
+                device_id, _ = self._parse_area_ref(area_ref)
+                self._selected_area_ref = area_ref
+                self._selected_area_name = selected["label"]
+                self._selected_device_id = device_id
+                return await self.async_step_area_scenario()
+
+        return self.async_show_form(
+            step_id="area_scenarios",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_AREA): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=area_options,
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        )
+                    )
+                }
+            ),
+        )
+
+    async def async_step_area_scenario(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Configure explicit scenarios for the selected area."""
+        if (
+            self._selected_area_ref is None
+            or self._selected_area_name is None
+            or self._selected_device_id is None
+        ):
+            return await self.async_step_area_scenarios()
+
+        errors: dict[str, str] = {}
+        options = dict(self.config_entry.options)
+        area_scenarios = deepcopy(options.get(CONF_AREA_SCENARIOS, {}))
+        current = area_scenarios.get(self._selected_area_ref, {})
+
+        if user_input is not None:
+            if user_input.pop(CONF_REMOVE_AREA_SCENARIO_MAPPING, False):
+                area_scenarios.pop(self._selected_area_ref, None)
+            else:
+                mapping = {
+                    key: value
+                    for key in (
+                        CONF_ARM_AWAY_SCENARIO,
+                        CONF_ARM_HOME_SCENARIO,
+                        CONF_DISARM_SCENARIO,
+                    )
+                    if (value := user_input.get(key)) not in (None, "")
+                }
+                if not mapping:
+                    errors["base"] = "mapping_required"
+                else:
+                    area_scenarios[self._selected_area_ref] = mapping
+
+            if not errors:
+                options[CONF_AREA_SCENARIOS] = area_scenarios
+                return self.async_create_entry(title="", data=options)
+
+        scenario_options = self._build_scenario_options(self._selected_device_id)
+        scenario_selector = selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=scenario_options,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+            )
+        )
+        scenario_schema: dict[Any, Any] = {}
+        for key in (
+            CONF_ARM_AWAY_SCENARIO,
+            CONF_ARM_HOME_SCENARIO,
+            CONF_DISARM_SCENARIO,
+        ):
+            value = current.get(key)
+            field = (
+                vol.Optional(key, description={"suggested_value": value})
+                if value is not None
+                else vol.Optional(key)
+            )
+            scenario_schema[field] = scenario_selector
+
+        return self.async_show_form(
+            step_id="area_scenario",
+            data_schema=vol.Schema(
+                {
+                    **scenario_schema,
+                    vol.Optional(
+                        CONF_REMOVE_AREA_SCENARIO_MAPPING,
+                        default=False,
+                    ): bool,
+                }
+            ),
+            errors=errors,
+            description_placeholders={"area_name": self._selected_area_name},
+        )
+
+    def _build_scenario_options(
+        self, device_id: int | None = None
+    ) -> list[selector.SelectOptionDict]:
         """Return panel scenarios as selector options (value=id, label=name)."""
         options: list[selector.SelectOptionDict] = []
         seen: set[str] = set()
         try:
             coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id]["coordinator"]
             for device in coordinator.data.get("devices", []):
+                if device_id is not None and device.get("device_id") != device_id:
+                    continue
                 for scenario in device.get("scenarios", []):
                     scenario_id = scenario.get("ScenarioId")
                     if scenario_id is None:
@@ -293,6 +434,44 @@ class InimAlarmOptionsFlow(config_entries.OptionsFlow):
         except (KeyError, AttributeError, TypeError):
             pass
         return options
+
+    def _build_area_mapping_options(self) -> list[selector.SelectOptionDict]:
+        """Return areas with device-scoped values for scenario mappings."""
+        options: list[selector.SelectOptionDict] = []
+        try:
+            coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id]["coordinator"]
+            devices = coordinator.data.get("devices", [])
+            show_device_name = len(devices) > 1
+            for device in devices:
+                device_id = device.get("device_id")
+                if device_id is None:
+                    continue
+                device_name = device.get("name", f"Device {device_id}")
+                for area in device.get("areas", []):
+                    area_id = area.get("AreaId")
+                    if area_id is None:
+                        continue
+                    area_name = area.get("Name", f"Area {area_id}")
+                    label = (
+                        f"{device_name} - {area_name}"
+                        if show_device_name
+                        else area_name
+                    )
+                    options.append(
+                        selector.SelectOptionDict(
+                            value=f"{device_id}:{area_id}",
+                            label=label,
+                        )
+                    )
+        except (KeyError, AttributeError, TypeError):
+            pass
+        return options
+
+    @staticmethod
+    def _parse_area_ref(area_ref: str) -> tuple[int, int]:
+        """Parse a device-scoped area reference."""
+        device_id, area_id = area_ref.split(":", 1)
+        return int(device_id), int(area_id)
 
     def _build_area_options(self) -> list[selector.SelectOptionDict]:
         """Return alarm areas as selector options (value=id, label=name)."""

--- a/custom_components/inim_alarm/const.py
+++ b/custom_components/inim_alarm/const.py
@@ -17,6 +17,9 @@ CONF_ARM_HOME_SCENARIO = "arm_home_scenario"
 CONF_DISARM_SCENARIO = "disarm_scenario"
 CONF_USER_CODE = "user_code"
 CONF_AWAY_ONLY_AREAS = "away_only_areas"
+CONF_AREA = "area"
+CONF_AREA_SCENARIOS = "area_scenarios"
+CONF_REMOVE_AREA_SCENARIO_MAPPING = "remove_area_scenario_mapping"
 
 # SIA-IP configuration
 CONF_ENABLE_SIA = "enable_sia"

--- a/custom_components/inim_alarm/strings.json
+++ b/custom_components/inim_alarm/strings.json
@@ -34,9 +34,20 @@
     }
   },
   "options": {
+    "error": {
+      "mapping_required": "Select at least one scenario or enable Remove mapping."
+    },
     "step": {
       "init": {
         "title": "INIM Alarm Options",
+        "description": "Choose which settings to configure.",
+        "menu_options": {
+          "general": "General settings",
+          "area_scenarios": "Per-area scenario mappings"
+        }
+      },
+      "general": {
+        "title": "General settings",
         "description": "Configure polling, SIA-IP, scenario mapping and area arming modes.",
         "data": {
           "scan_interval": "Polling interval (seconds)",
@@ -57,6 +68,29 @@
           "arm_home_scenario": "Panel scenario to activate for Armed Home (e.g. Night/partial). Leave empty to arm all areas.",
           "disarm_scenario": "Panel scenario to activate for Disarm. Leave empty to disarm all areas.",
           "away_only_areas": "Areas that should offer Armed Away but not Armed Home."
+        }
+      },
+      "area_scenarios": {
+        "title": "Per-area scenario mappings",
+        "description": "Choose an area to map. You can reopen this screen to configure another area.",
+        "data": {
+          "area": "Area"
+        }
+      },
+      "area_scenario": {
+        "title": "Scenarios for {area_name}",
+        "description": "Map each action to an explicit panel scenario. Leave actions blank to keep the InsertAreas fallback.",
+        "data": {
+          "arm_away_scenario": "Armed Away scenario",
+          "arm_home_scenario": "Armed Home scenario",
+          "disarm_scenario": "Disarm scenario",
+          "remove_area_scenario_mapping": "Remove mapping"
+        },
+        "data_description": {
+          "arm_away_scenario": "Scenario to activate when this area is armed Away.",
+          "arm_home_scenario": "Scenario to activate when this area is armed Home. Leave blank for Away-only areas.",
+          "disarm_scenario": "Scenario to activate when this area is disarmed.",
+          "remove_area_scenario_mapping": "Delete all explicit scenario mappings for this area."
         }
       }
     }

--- a/custom_components/inim_alarm/translations/en.json
+++ b/custom_components/inim_alarm/translations/en.json
@@ -34,9 +34,20 @@
     }
   },
   "options": {
+    "error": {
+      "mapping_required": "Select at least one scenario or enable Remove mapping."
+    },
     "step": {
       "init": {
         "title": "INIM Alarm Options",
+        "description": "Choose which settings to configure.",
+        "menu_options": {
+          "general": "General settings",
+          "area_scenarios": "Per-area scenario mappings"
+        }
+      },
+      "general": {
+        "title": "General settings",
         "description": "Configure polling, SIA-IP, scenario mapping and area arming modes.",
         "data": {
           "scan_interval": "Polling interval (seconds)",
@@ -57,6 +68,29 @@
           "arm_home_scenario": "Panel scenario to activate for Armed Home (e.g. Night/partial). Leave empty to arm all areas.",
           "disarm_scenario": "Panel scenario to activate for Disarm. Leave empty to disarm all areas.",
           "away_only_areas": "Areas that should offer Armed Away but not Armed Home."
+        }
+      },
+      "area_scenarios": {
+        "title": "Per-area scenario mappings",
+        "description": "Choose an area to map. You can reopen this screen to configure another area.",
+        "data": {
+          "area": "Area"
+        }
+      },
+      "area_scenario": {
+        "title": "Scenarios for {area_name}",
+        "description": "Map each action to an explicit panel scenario. Leave actions blank to keep the InsertAreas fallback.",
+        "data": {
+          "arm_away_scenario": "Armed Away scenario",
+          "arm_home_scenario": "Armed Home scenario",
+          "disarm_scenario": "Disarm scenario",
+          "remove_area_scenario_mapping": "Remove mapping"
+        },
+        "data_description": {
+          "arm_away_scenario": "Scenario to activate when this area is armed Away.",
+          "arm_home_scenario": "Scenario to activate when this area is armed Home. Leave blank for Away-only areas.",
+          "disarm_scenario": "Scenario to activate when this area is disarmed.",
+          "remove_area_scenario_mapping": "Delete all explicit scenario mappings for this area."
         }
       }
     }

--- a/custom_components/inim_alarm/translations/it.json
+++ b/custom_components/inim_alarm/translations/it.json
@@ -34,9 +34,20 @@
     }
   },
   "options": {
+    "error": {
+      "mapping_required": "Seleziona almeno uno scenario oppure abilita Rimuovi mappatura."
+    },
     "step": {
       "init": {
         "title": "Opzioni INIM Alarm",
+        "description": "Scegli quali impostazioni configurare.",
+        "menu_options": {
+          "general": "Impostazioni generali",
+          "area_scenarios": "Mappatura scenari per area"
+        }
+      },
+      "general": {
+        "title": "Impostazioni generali",
         "description": "Configura polling, SIA-IP, mappatura degli scenari e modalita di inserimento delle aree.",
         "data": {
           "scan_interval": "Intervallo di polling (secondi)",
@@ -57,6 +68,29 @@
           "arm_home_scenario": "Scenario del pannello da attivare per l'inserimento parziale (es. Notte/parziale). Lascia vuoto per inserire tutte le aree.",
           "disarm_scenario": "Scenario del pannello da attivare per il disinserimento. Lascia vuoto per disinserire tutte le aree.",
           "away_only_areas": "Aree che devono offrire solo Inserimento Totale, senza Inserimento Parziale."
+        }
+      },
+      "area_scenarios": {
+        "title": "Mappatura scenari per area",
+        "description": "Scegli un'area da configurare. Puoi riaprire questa schermata per configurare un'altra area.",
+        "data": {
+          "area": "Area"
+        }
+      },
+      "area_scenario": {
+        "title": "Scenari per {area_name}",
+        "description": "Associa ogni azione a uno scenario esplicito del pannello. Lascia vuote le azioni per mantenere il fallback InsertAreas.",
+        "data": {
+          "arm_away_scenario": "Scenario Inserimento Totale",
+          "arm_home_scenario": "Scenario Inserimento Parziale",
+          "disarm_scenario": "Scenario Disinserimento",
+          "remove_area_scenario_mapping": "Rimuovi mappatura"
+        },
+        "data_description": {
+          "arm_away_scenario": "Scenario da attivare quando l'area viene inserita in modalita Totale.",
+          "arm_home_scenario": "Scenario da attivare quando l'area viene inserita in modalita Parziale. Lascia vuoto per le aree solo Totale.",
+          "disarm_scenario": "Scenario da attivare quando l'area viene disinserita.",
+          "remove_area_scenario_mapping": "Elimina tutte le mappature esplicite per questa area."
         }
       }
     }


### PR DESCRIPTION
## Summary

- Add explicit per-device, per-area scenario mappings for arm away, arm home, and disarm.
- Use the configured scenario when a mapping exists.
- Preserve the existing `InsertAreas` behavior for areas without a mapping.
- Keep `away_only` enforcement intact, including rejecting arm-home for those areas.
- Add an options-flow UI for adding, changing, and removing mappings.

## Motivation

Some INIM configurations acknowledge `InsertAreas` without applying the requested state to independently controlled areas. Explicit scenario mappings make those areas controllable without inferring scenario names, area masks, or modes.

This follows the guidance from pla10/homeassistant_inim_alarm#11: mappings are fully opt-in and explicit, with no guessing. Existing installations retain their current behavior until a mapping is configured.

## Context

This is the clean upstream follow-up to:

- pla10/homeassistant_inim_alarm#11
- SudoPlz/homeassistant_inim_alarm#1

The branch has been rebased onto the current upstream `main` after PR 11 was merged.

## Validation

- Python compilation passes for the integration.
- Translation and strings JSON files parse successfully.
- `git diff --check` passes.
- The rebased commit is patch-equivalent to the previously reviewed stacked change.

Here's what it looks like:
<img width="489" height="629" alt="Screenshot 2026-06-16 at 2 36 54 AM" src="https://github.com/user-attachments/assets/0d8af91c-25df-46ca-9275-319dcf7a2c36" />

