### PR TITLE
Add per-zone alarm memory binary sensors

### DIFF
--- a/custom_components/inim_alarm/binary_sensor.py
+++ b/custom_components/inim_alarm/binary_sensor.py
@@ -101,6 +101,15 @@ async def async_setup_entry(
                     zone_name=zone_name,
                 )
             )
+            entities.append(
+                InimZoneAlarmMemoryBinarySensor(
+                    coordinator=coordinator,
+                    device_id=device_id,
+                    device_name=device_name,
+                    zone_id=zone_id,
+                    zone_name=zone_name,
+                )
+            )
 
     async_add_entities(entities)
 
@@ -181,6 +190,83 @@ class InimZoneBinarySensor(
             "terminal_id": zone.get("TerminalId"),
             "voltage": zone.get("Voltage", 0) if zone.get("Voltage", 0) > 0 else None,
             "power": zone.get("Power", 0) if zone.get("Power", 0) > 0 else None,
+        }
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()
+
+
+class InimZoneAlarmMemoryBinarySensor(
+    CoordinatorEntity[InimDataUpdateCoordinator], BinarySensorEntity
+):
+    """Representation of an INIM zone alarm memory binary sensor."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.SAFETY
+
+    def __init__(
+        self,
+        coordinator: InimDataUpdateCoordinator,
+        device_id: int,
+        device_name: str,
+        zone_id: int,
+        zone_name: str,
+    ) -> None:
+        """Initialize the alarm memory binary sensor."""
+        super().__init__(coordinator)
+        self._device_id = device_id
+        self._device_name = device_name
+        self._zone_id = zone_id
+        self._zone_name = zone_name
+        self._attr_unique_id = f"{device_id}_zone_{zone_id}_alarm_memory"
+        self._attr_name = f"Allarme {zone_name}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        device = self.coordinator.get_device(self._device_id)
+        if not device:
+            return DeviceInfo(
+                identifiers={(DOMAIN, str(self._device_id))},
+                manufacturer=MANUFACTURER,
+            )
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, str(self._device_id))},
+            manufacturer=MANUFACTURER,
+            model=device.get("model"),
+            name=device.get("name", "INIM Alarm"),
+            sw_version=device.get("firmware"),
+            serial_number=device.get("serial_number"),
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the zone has alarm memory."""
+        zone = self.coordinator.get_zone(self._device_id, self._zone_id)
+        if not zone:
+            return None
+
+        return zone.get("AlarmMemory", 0) > 0
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        zone = self.coordinator.get_zone(self._device_id, self._zone_id)
+        if not zone:
+            return {}
+
+        return {
+            ATTR_DEVICE_ID: self._device_id,
+            ATTR_ZONE_ID: self._zone_id,
+            ATTR_ALARM_MEMORY: zone.get("AlarmMemory", 0) > 0,
+            ATTR_TAMPER_MEMORY: zone.get("TamperMemory", 0) > 0,
+            ATTR_BYPASSED: zone.get("Bypassed", 0) > 0,
+            "source_zone_name": self._zone_name,
+            "areas": zone.get("Areas"),
+            "type": zone.get("Type"),
         }
 
     @callback

--- a/custom_components/inim_alarm/binary_sensor.py
+++ b/custom_components/inim_alarm/binary_sensor.py
@@ -65,6 +65,11 @@ def _guess_device_class(zone_name: str) -> BinarySensorDeviceClass:
     return BinarySensorDeviceClass.OPENING
 
 
+def _is_zone_output(zone: dict[str, Any]) -> bool:
+    """Return true when the item represents an output instead of an alarm zone."""
+    return zone.get("Type") == 4
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -101,15 +106,16 @@ async def async_setup_entry(
                     zone_name=zone_name,
                 )
             )
-            entities.append(
-                InimZoneAlarmMemoryBinarySensor(
-                    coordinator=coordinator,
-                    device_id=device_id,
-                    device_name=device_name,
-                    zone_id=zone_id,
-                    zone_name=zone_name,
+            if not _is_zone_output(zone):
+                entities.append(
+                    InimZoneAlarmMemoryBinarySensor(
+                        coordinator=coordinator,
+                        device_id=device_id,
+                        device_name=device_name,
+                        zone_id=zone_id,
+                        zone_name=zone_name,
+                    )
                 )
-            )
 
     async_add_entities(entities)
 

--- a/custom_components/inim_alarm/binary_sensor.py
+++ b/custom_components/inim_alarm/binary_sensor.py
@@ -210,7 +210,7 @@ class InimZoneAlarmMemoryBinarySensor(
     """Representation of an INIM zone alarm memory binary sensor."""
 
     _attr_has_entity_name = True
-    _attr_device_class = BinarySensorDeviceClass.SAFETY
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
 
     def __init__(
         self,

--- a/custom_components/inim_alarm/binary_sensor.py
+++ b/custom_components/inim_alarm/binary_sensor.py
@@ -210,7 +210,7 @@ class InimZoneAlarmMemoryBinarySensor(
     """Representation of an INIM zone alarm memory binary sensor."""
 
     _attr_has_entity_name = True
-    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_device_class = BinarySensorDeviceClass.SAFETY
 
     def __init__(
         self,

--- a/custom_components/inim_alarm/coordinator.py
+++ b/custom_components/inim_alarm/coordinator.py
@@ -399,11 +399,18 @@ class InimDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         has_changes = False
         for device in self.data.get("devices", []):
             for idx, zone in enumerate(device.get("zones", [])):
-                if zone.get("ZoneId") == zone_id:
+                z_id = zone.get("ZoneId")
+                
+                # Ignora le zone senza ID
+                if z_id is None:
+                    continue
+                
+                # Handle INIM Cloud 1000 offset for wireless and double zones
+                if z_id == zone_id or z_id % 1000 == zone_id:
                     device["zones"][idx].update(status_update)
                     has_changes = True
                     _LOGGER.debug(
-                        "SIA update zone %s: %s", zone.get("Name", zone_id), status_update
+                        "SIA update zone %s: %s", zone.get("Name", z_id), status_update
                     )
                     break
             if has_changes:


### PR DESCRIPTION
## Summary

This adds a second binary sensor for each visible INIM zone to expose the zone `AlarmMemory` flag as a real Home Assistant entity.

Currently, the normal zone binary sensor represents open/closed status using the zone `Status` field, while `AlarmMemory` is only exposed as an attribute. Since integrations such as HomeKit cannot expose or notify on attributes as separate accessories, users cannot easily identify which zone caused an alarm.

This change keeps the existing zone binary sensors unchanged and adds a new per-zone alarm memory binary sensor named `Allarme <zone name>`. The new sensor turns on when the zone `AlarmMemory` flag is active and can be used in dashboards, automations, and HomeKit bridges to show the exact zone that triggered the alarm.

Outputs/relay-style zones are skipped for alarm memory sensors, so non-alarm outputs such as lights, relays, heating, or door-release outputs are not exposed as alarm memory entities.

## Testing

Tested locally with INIM Prime / Home Assistant:

- Normal open/closed zone sensors continue to work.
- New `Allarme <zone name>` sensors are created for real alarm zones.
- Triggering an alarm on a zone turns on the corresponding alarm memory sensor.
- Clearing alarm memories on the panel turns the corresponding alarm memory sensor back off.
- Opening/closing other windows without alarm does not set alarm memory.
- Output/relay-style items are not useful as alarm memory sensors and are skipped.